### PR TITLE
Clarify the situation with .t extension

### DIFF
--- a/solutions/language/PATH-TO-RAKU.md
+++ b/solutions/language/PATH-TO-RAKU.md
@@ -149,9 +149,9 @@ will continue to be supported for 6.e.  In 6.f, the `.pm`, `.pm6` and `.pod6`
 extensions could be marked as DEPRECATED, causing a message to be generated
 when the module is loaded.
 
-For testing, the extension `.rakutest` should be used, while the old `.t`
-extension will continue to be supported for 6.e, with deprecation messages
-appearing from 6.f onward.
+For testing, the extensions `.rakutest` and `.t` should be used, while the
+extension `.t6` will continue to be supported for 6.e, with deprecation
+messages appearing from 6.f onward.
 
 On Windows, installers should add a `.raku` association alongside the `.p6`
 association for the time being. Around the time of 6.f, a `.p6` association


### PR DESCRIPTION
After carefully considering @AlexDaniel review, #108, and
[some IRC chatting](https://colabti.org/irclogger/irclogger_log/perl6-dev?date=2019-09-26#l179),
I would like to propose to remove the part about `.t` deprecation. I do
it with a some regret as this proposal would postpone the voting if
accepted, but:

1. Tools currently supporting TAP are used to this extension. We can't ask all of them to produce the deprecation message for Raku only.
2. This would allow a user to choose the extension more suitable to the tools he/she is using and even up to his personal preferences.
3. In a way, this conform to TIMTOWTDI.

**NOTE** Not done yet, requires additional changes.